### PR TITLE
remove width that limits breadcrumbs width

### DIFF
--- a/src/components/PageHeader/index.scss
+++ b/src/components/PageHeader/index.scss
@@ -10,7 +10,6 @@
   }
 
   .ui.breadcrumb {
-    width: 400px;
     .icon.divider {
       margin: 0 10px;
       color: #98aeca;


### PR DESCRIPTION
FIX Product Tracker: When clicking in Ungrouped the text wraps instead of going to the right.