### PR TITLE
BUGFR-186: Categories select all bug

### DIFF
--- a/src/containers/Synthesis/ProfitFinderFilterSection/index.tsx
+++ b/src/containers/Synthesis/ProfitFinderFilterSection/index.tsx
@@ -391,6 +391,7 @@ function ProfitFinderFilterSection(props: Props) {
     const data = filterState;
 
     setSelectAll(false);
+    localStorage.setItem('filterSelectAll', JSON.stringify(false));
     const allData = _.map(allFilter, filter => {
       if (!filter.radio) {
         _.map(filter.data, allFilterData => {


### PR DESCRIPTION
If you unchecked a category and then do a refresh, the select all will be active again, it should be inactive. 