### PR TITLE
BUGFR-548: remove default rounding to integer in all StepLineChart

### DIFF
--- a/src/components/Chart/StepLineChart.tsx
+++ b/src/components/Chart/StepLineChart.tsx
@@ -58,9 +58,6 @@ const renderStepLineChartOptions = (options: StepLineChartOptions) => {
           ...{
             type: 'line',
             step: true,
-            tooltip: {
-              valueDecimals: 0,
-            },
           },
         };
       }),


### PR DESCRIPTION
this lets the data points itself determine their own rounding: so now price is 2.d.p, rating is 1.d.p and review count is whole number 